### PR TITLE
Move Balance to separate namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Methods are provided within `client.vouchers.*` namespace.
 - [Get Voucher](#get-voucher)
 - [Update Voucher](#update-voucher)
 - [Delete Voucher](#delete-voucher)
+- [Add Gift Voucher Balance](#add-gift-voucher-balance)
 - [List Vouchers](#list-vouchers)
 - [Enable Voucher](#enable-voucher)
 - [Disable Voucher](#disable-voucher)
@@ -140,6 +141,10 @@ client.vouchers.update(voucher)
 ```javascript
 client.vouchers.delete(code)
 client.vouchers.delete(code, {force: true})
+```
+#### [Add Gift Voucher Balance]
+```javascript
+client.vouchers.balance.create({code, amount})
 ```
 #### [List Vouchers]
 ```javascript
@@ -501,6 +506,7 @@ Bug reports and pull requests are welcome through [GitHub Issues](https://github
 [Enable Voucher]: https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq#enable-voucher
 [Disable Voucher]: https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq#disable-voucher
 [Import Vouchers]: https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq#import-vouchers-1
+[Add Gift Voucher Balance]: https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq#add-gift-voucher-balance
 
 [Create Campaign]: https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq#create-campaign
 [Get Campaign]: https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq#get-campaign

--- a/src/Balance.js
+++ b/src/Balance.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const {encode} = require('./helpers')
+
+module.exports = class Balance {
+  constructor (client) {
+    this.client = client
+  }
+
+  create (voucher, callback) {
+    return this.client.post(`/vouchers/${encode(voucher.code)}/balance`, voucher, callback)
+  }
+}

--- a/src/Vouchers.js
+++ b/src/Vouchers.js
@@ -3,8 +3,11 @@
 const {encode, isFunction, isObject} = require('./helpers')
 
 module.exports = class Vouchers {
-  constructor (client) {
+  constructor (client, balance) {
     this.client = client
+
+    // public
+    this.balance = balance
   }
 
   create (voucher, callback) {
@@ -28,10 +31,6 @@ module.exports = class Vouchers {
     return this.client.delete(`/vouchers/${encode(code)}`, callback, {
       qs: {force: !!params.force}
     })
-  }
-
-  balance (voucher, callback) {
-    return this.client.post(`/vouchers/${encode(voucher.code)}/balance`, voucher, callback)
   }
 
   list (params, callback) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const ApiClient = require('./ApiClient')
 const Campaigns = require('./Campaigns')
 const Distributions = require('./Distributions')
+const Balance = require('./Balance')
 const Vouchers = require('./Vouchers')
 const Validations = require('./Validations')
 const Redemptions = require('./Redemptions')
@@ -16,7 +17,8 @@ module.exports = function (options) {
   assertOption(options, 'clientSecretKey')
 
   const client = new ApiClient(options)
-  const vouchers = new Vouchers(client)
+  const balance = new Balance(client)
+  const vouchers = new Vouchers(client, balance)
   const campaigns = new Campaigns(client)
   const distributions = new Distributions(client)
   const validations = new Validations(client)

--- a/test/vouchers-api.spec.js
+++ b/test/vouchers-api.spec.js
@@ -108,7 +108,7 @@ describe('Vouchers API', function () {
       })
       .reply(200, {})
 
-    client.vouchers.balance({
+    client.vouchers.balance.create({
       code: 'test-code',
       amount: 2000
     })


### PR DESCRIPTION
@jordansexton there will be slight change in namespacing for new method you've introduced in #58.

We had a discussion in the team and `Balance` deserves for separate namespace, there is wider idea behind this. So adding a balance is done via: `client.vouchers.balance.create(voucher)`.

If you have any comments please share. Once it's fine for you we will proceed with the release.