### PR TITLE
Distributions publish outdated interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ All other examples in the readme use promises but they could be as well written 
 
 ## API
 
-This SDK is fully consistent with restufl API Voucherify provides.
-Detalied description and example responses  you will find at [official docs](https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq).
-Method headers point to more detalied params description you can use.
+This SDK is fully consistent with restful API Voucherify provides.
+You will find detailed description and example responses at [official docs](https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq).
+Method headers point to more detailed descriptions of params you can use.
 
 ### Vouchers API
 Methods are provided within `client.vouchers.*` namespace.
@@ -135,7 +135,7 @@ Methods are provided within `client.vouchers.*` namespace.
 ```javascript
 client.vouchers.create(voucher)
 ```
-Check [voucher oject](https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq#the-voucher-object).
+Check [voucher object](https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq#the-voucher-object).
 
 #### [Get Voucher]
 ```javascript
@@ -597,7 +597,7 @@ consistent structure, described in details in our [API reference](https://docs.v
 Bug reports and pull requests are welcome through [GitHub Issues](https://github.com/voucherifyio/voucherify-nodejs-sdk/issues).
 
 ## Changelog
-- **2018-01-20** - `2.13.1` Remove outdated `client.distributions.publish(campaignName)` method interface
+- **2018-01-21** - `2.13.1` - Remove outdated `client.distributions.publish(campaignName)` method interface
 - **2017-12-06** - `2.13.0`
   - Fix voucher validation vulnerability
   - Allow to force delete Products and SKUs

--- a/README.md
+++ b/README.md
@@ -220,7 +220,6 @@ Methods are provided within `client.distributions.*` namespace.
 
 #### [Publish Voucher]
 ```javascript
-client.distributions.publish(campaignName)
 client.distributions.publish(params)
 ```
 #### [Create Export]
@@ -598,6 +597,7 @@ consistent structure, described in details in our [API reference](https://docs.v
 Bug reports and pull requests are welcome through [GitHub Issues](https://github.com/voucherifyio/voucherify-nodejs-sdk/issues).
 
 ## Changelog
+- **2018-01-20** - `2.13.1` Remove outdated `client.distributions.publish(campaignName)` method interface
 - **2017-12-06** - `2.13.0`
   - Fix voucher validation vulnerability
   - Allow to force delete Products and SKUs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voucherify",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "homepage": "http://www.voucherify.io",
   "description": "Official Voucherify SDK for Node.js",
   "author": "Voucherify",

--- a/src/Distributions.js
+++ b/src/Distributions.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {encode, isFunction} = require('./helpers')
+const {isFunction} = require('./helpers')
 
 module.exports = class Distributions {
   constructor (client, exportsNamespace) {

--- a/src/Distributions.js
+++ b/src/Distributions.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {encode, isString, isObject, isFunction} = require('./helpers')
+const {encode, isFunction} = require('./helpers')
 
 module.exports = class Distributions {
   constructor (client, exportsNamespace) {
@@ -19,12 +19,6 @@ module.exports = class Distributions {
   }
 
   publish (params, callback) {
-    if (isString(params)) {
-      return this.client.post('/vouchers/publish', {campaign: encode(params)}, callback)
-    }
-
-    if (isObject(params)) {
-      return this.client.post('/vouchers/publish', params, callback)
-    }
+    return this.client.post('/vouchers/publish', params, callback)
   }
 }

--- a/test/distributions-api.spec.js
+++ b/test/distributions-api.spec.js
@@ -14,31 +14,19 @@ describe('Distributions API', function () {
   })
 
   describe('publish voucher', function () {
-    it('should publish by camaign name', function (done) {
-      var server = nock('https://api.voucherify.io', reqWithBody)
-        .post('/v1/vouchers/publish', {
-          campaign: 'test-campaign'
-        })
-        .reply(200, {})
-
-      client.distributions.publish('test-campaign')
-      .then(function () {
-        server.done()
-        done()
-      })
-    })
-
     it('should publish by voucher', function (done) {
       var server = nock('https://api.voucherify.io', reqWithBody)
         .post('/v1/vouchers/publish', {
           campaign: 'test-campaign',
-          voucher: 'test-voucher'
+          voucher: 'test-voucher',
+          customer: 'test@custom.er'
         })
         .reply(200, {})
 
       client.distributions.publish({
         campaign: 'test-campaign',
-        voucher: 'test-voucher'
+        voucher: 'test-voucher',
+        customer: 'test@custom.er'
       })
       .then(function () {
         server.done()


### PR DESCRIPTION
- **2018-01-21** - `2.13.1` - Remove outdated `client.distributions.publish(campaignName)` method interface