### PR TITLE
Fixed the way string errors are handled

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -6,6 +6,9 @@ const packageJson = require('../package')
 
 const errorMessage = (statusCode, body) => {
   body = body || {}
+  if (typeof body === "string") {
+    return 'Unexpected status code: ' + statusCode + ' - Details: ' + body;
+  }
   body.toString = function () {
     return `Unexpected status code: ${statusCode} - Details: ${JSON.stringify(body)}`
   }


### PR DESCRIPTION
There is an issue when string body is returned, we have received `Uncaught exception` with node `4.8.4`. Fix changes the way such specific errors are handled.