### PR TITLE
Add create method for distributions publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Methods are provided within `client.distributions.*` namespace.
 - [Get Export](#get-export)
 - [Delete Export](#delete-export)
 - [List publications](#list-publications)
+- [Create publication](#create-publication)
 
 #### [Publish Voucher]
 ```javascript
@@ -267,6 +268,10 @@ client.distributions.exports.delete(exportId)
 ```javascript
 client.distributions.publications.list()
 client.distributions.publications.list(params)
+```
+#### [Create publication]
+```javascript
+client.distributions.publications.create(params)
 ```
 
 ---
@@ -823,6 +828,10 @@ consistent structure, described in details in our [API reference](https://docs.v
 Bug reports and pull requests are welcome through [GitHub Issues](https://github.com/voucherifyio/voucherify-nodejs-sdk/issues).
 
 ## Changelog
+- **2019-11-14** - `3.1.0` - Added support for new method
+    - Distributions
+        - Publications
+            - Create
 - **2019-06-19** - `3.0.0` - Added support for custom API endpoint, that allows to connect to projects created in specific Voucherify region.
 - **2019-05-27** - `2.23.0` - Added support for the methods related to the Loyalty Programs
   - Rewards

--- a/src/Distributions.js
+++ b/src/Distributions.js
@@ -14,6 +14,9 @@ module.exports = class Distributions {
         }
 
         return client.get('/publications', params, callback)
+      },
+      create (params, callback) {
+        return client.post('/publications', params, callback)
       }
     }
   }

--- a/test/distributions-api.spec.js
+++ b/test/distributions-api.spec.js
@@ -35,6 +35,40 @@ describe('Distributions API', function () {
     })
   })
 
+  describe('create publication', function () {
+    it('should create publication', function (done) {
+      var server = nock('https://api.voucherify.io', reqWithBody)
+        .post('/v1/publications', {
+          campaign: {
+            name: 'test-campaign',
+            count: '5'
+          },
+          customer: {
+              source_id: 'test-source-id',
+              email: 'test@custom.er',
+              name: 'Test customer name'
+          }
+        })
+        .reply(200, {})
+
+      client.distributions.publications.create({
+        campaign: {
+          name: 'test-campaign',
+          count: '5'
+        },
+        customer: {
+            source_id: 'test-source-id',
+            email: 'test@custom.er',
+            name: 'Test customer name'
+        }
+      })
+      .then(function () {
+        server.done()
+        done()
+      })
+    })
+  })
+
   describe('list publications', function () {
     it('should list all publications', function (done) {
       var server = nock('https://api.voucherify.io', reqWithoutBody)

--- a/test/distributions-api.spec.js
+++ b/test/distributions-api.spec.js
@@ -44,9 +44,9 @@ describe('Distributions API', function () {
             count: '5'
           },
           customer: {
-              source_id: 'test-source-id',
-              email: 'test@custom.er',
-              name: 'Test customer name'
+            source_id: 'test-source-id',
+            email: 'test@custom.er',
+            name: 'Test customer name'
           }
         })
         .reply(200, {})
@@ -57,9 +57,9 @@ describe('Distributions API', function () {
           count: '5'
         },
         customer: {
-            source_id: 'test-source-id',
-            email: 'test@custom.er',
-            name: 'Test customer name'
+          source_id: 'test-source-id',
+          email: 'test@custom.er',
+          name: 'Test customer name'
         }
       })
       .then(function () {


### PR DESCRIPTION
There is no method like Create Publication in Node SDK.
I decided to add this method, because it's already available in Voucherify API -> https://docs.voucherify.io/reference?utm_source=github&utm_medium=sdk&utm_campaign=acq#create-publication