### PR TITLE
Allow to scroll customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,20 @@ client.customers.delete(customerId)
 client.customers.list()
 client.customers.list(params)
 ```
+#### [Scroll through customers]
+Standard list customers API has limitation of available pages to be shown equal to 100.
+To cover cases when you would like to fetch more, you must use scroll capabilities.
+
+```javascript
+async function () {
+  for await (const customer of client.customers.scroll(params)) {
+    console.log('Customer', customer)
+  }
+}
+```
+`params` argument is consistent with `list` method.
+Keep in mind `scroll` doesn't support callback version.
+
 #### [Update Customer's Consents]
 ```javascript
 client.customers.updateConsents(customer, consents)

--- a/README.md
+++ b/README.md
@@ -455,6 +455,20 @@ async function () {
 `params` argument is consistent with `list` method.
 Keep in mind `scroll` doesn't support callback version.
 
+If you want to limit results by customer creation date.
+
+```javascript
+async function () {
+  for await (const customer of client.customers.scroll({
+    starting_after: "2020-01-01", // optional
+    ending_before: "2020-02-01", // optional
+    ...params})
+  ) {
+    console.log('Customer', customer)
+  }
+}
+```
+
 #### [Update Customer's Consents]
 ```javascript
 client.customers.updateConsents(customer, consents)

--- a/examples/customers.js
+++ b/examples/customers.js
@@ -7,9 +7,9 @@ const voucherify = voucherifyClient({
   clientSecretKey: '3266b9f8-e246-4f79-bdf0-833929b1380c'
 })
 
-async function scrollCustomers() {
-  for await (const customer of voucherify.customers.scroll({limit: 5})) {
-    console.log("Customer", customer)
+async function scrollCustomers () {
+  for await (const customer of voucherify.customers.scroll({ limit: 5 })) {
+    console.log('Customer', customer)
   }
 }
 

--- a/examples/customers.js
+++ b/examples/customers.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const voucherifyClient = require('../src/index')
+
+const voucherify = voucherifyClient({
+  applicationId: 'c70a6f00-cf91-4756-9df5-47628850002b',
+  clientSecretKey: '3266b9f8-e246-4f79-bdf0-833929b1380c'
+})
+
+async function scrollCustomers() {
+  for await (const customer of voucherify.customers.scroll({limit: 5})) {
+    console.log("Customer", customer)
+  }
+}
+
+scrollCustomers().catch((err) => console.error(err))

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "scripts": {
     "test": "mocha",
-    "lint": "standard"
+    "lint": "standard --fix"
   }
 }

--- a/src/Customers.js
+++ b/src/Customers.js
@@ -27,9 +27,9 @@ module.exports = class Customers {
 
   async * scroll (params = {}) {
     let response = await this.client.get('/customers', Object.assign({}, params, {scroll: true}))
-    let createdAfter = params.created_after
-    let createdBefore = params.created_before
-    let direction = (createdAfter || !createdBefore) ? 'desc' : 'asc'
+    let startingAfter = params.starting_after
+    let endingBefore = params.ending_before
+    let direction = (startingAfter || !endingBefore) ? 'desc' : 'asc'
 
     while (true) {
       if (response.customers.length === 0) {
@@ -38,9 +38,9 @@ module.exports = class Customers {
       for (const customer of response.customers) {
         // comparing ISOs
         if (direction === 'asc') {
-          createdBefore = createdBefore < customer.created_at ? createdBefore : customer.created_at
+          endingBefore = endingBefore < customer.created_at ? endingBefore : customer.created_at
         } else {
-          createdAfter = createdAfter > customer.created_at ? createdAfter : customer.created_at
+          startingAfter = startingAfter > customer.created_at ? startingAfter : customer.created_at
         }
         yield customer
       }
@@ -52,8 +52,8 @@ module.exports = class Customers {
         '/customers',
         Object.assign({}, params, {
           scroll: true,
-          created_before: createdBefore,
-          created_after: createdAfter
+          ending_before: endingBefore,
+          starting_after: startingAfter
         })
       )
     }

--- a/src/Customers.js
+++ b/src/Customers.js
@@ -28,7 +28,7 @@ module.exports = class Customers {
   async * scroll (params = {}) {
     let startingAfter = params.starting_after
     let endingBefore = params.ending_before
-    let direction = (startingAfter || !endingBefore) ? 'desc' : 'asc'
+    const direction = (startingAfter || !endingBefore) ? 'desc' : 'asc'
 
     let response = await this.client.get('/customers', Object.assign(
       {}, params, {
@@ -39,7 +39,7 @@ module.exports = class Customers {
 
     while (true) {
       if (response.customers.length === 0) {
-        break;
+        break
       }
       for (const customer of response.customers) {
         // comparing ISOs
@@ -51,7 +51,7 @@ module.exports = class Customers {
         yield customer
       }
       if (!response.has_more) {
-        break;
+        break
       }
 
       response = await this.client.get(

--- a/src/Customers.js
+++ b/src/Customers.js
@@ -26,10 +26,16 @@ module.exports = class Customers {
   }
 
   async * scroll (params = {}) {
-    let response = await this.client.get('/customers', Object.assign({}, params, {scroll: true}))
     let startingAfter = params.starting_after
     let endingBefore = params.ending_before
     let direction = (startingAfter || !endingBefore) ? 'desc' : 'asc'
+
+    let response = await this.client.get('/customers', Object.assign(
+      {}, params, {
+        starting_after: (startingAfter || endingBefore) ? startingAfter : '1970-01-01T00:00:00Z',
+        ending_before: endingBefore
+      }
+    ))
 
     while (true) {
       if (response.customers.length === 0) {
@@ -51,7 +57,6 @@ module.exports = class Customers {
       response = await this.client.get(
         '/customers',
         Object.assign({}, params, {
-          scroll: true,
           ending_before: endingBefore,
           starting_after: startingAfter
         })

--- a/test/customers-api.spec.js
+++ b/test/customers-api.spec.js
@@ -91,7 +91,7 @@ describe('Customers API', function () {
         .reply(200, {has_more: true, customers: [{created_at: '2020-01-01T00:00:00Z'}, {created_at: '2020-01-02T00:00:00Z'}]})
 
         .get('/v1/customers')
-        .query({ scroll: true, filters: 'value', created_after: '2020-01-02T00:00:00Z' })
+        .query({ scroll: true, filters: 'value', starting_after: '2020-01-02T00:00:00Z' })
         .reply(200, {has_more: false, customers: [{created_at: '2020-01-03T00:00:00Z'}]})
 
 
@@ -109,19 +109,19 @@ describe('Customers API', function () {
       let now = new Date().toISOString()
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
-        .query({ scroll: true, created_before: now, filters: 'value' })
+        .query({ scroll: true, ending_before: now, filters: 'value' })
         .reply(200, {has_more: true, customers: [
           {created_at: '2020-01-04T00:00:00Z'},
           {created_at: '2020-01-03T00:00:00Z'},
           {created_at: '2020-01-02T00:00:00Z'}
         ]})
         .get('/v1/customers')
-        .query({ scroll: true, filters: 'value', created_before: '2020-01-02T00:00:00Z' })
+        .query({ scroll: true, filters: 'value', ending_before: '2020-01-02T00:00:00Z' })
         .reply(200, {has_more: false, customers: [{created_at: '2020-01-01T00:00:00Z'}]})
 
 
       let callCount = 0
-      for await (const customer of client.customers.scroll({ filters: 'value', created_before: now })) {
+      for await (const customer of client.customers.scroll({ filters: 'value', ending_before: now })) {
         ++callCount
       }
 

--- a/test/customers-api.spec.js
+++ b/test/customers-api.spec.js
@@ -82,25 +82,26 @@ describe('Customers API', function () {
     })
   })
 
-
   describe('scroll', async function () {
     it('should scroll customers descending', async function () {
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
         .query({ filters: 'value', starting_after: '1970-01-01T00:00:00Z' })
-        .reply(200, {has_more: true, customers: [{created_at: '2020-01-01T00:00:00Z'}, {created_at: '2020-01-02T00:00:00Z'}]})
+        .reply(200, { has_more: true, customers: [{ created_at: '2020-01-01T00:00:00Z' }, { created_at: '2020-01-02T00:00:00Z' }] })
 
         .get('/v1/customers')
         .query({ filters: 'value', starting_after: '2020-01-02T00:00:00Z' })
-        .reply(200, {has_more: false, customers: [{created_at: '2020-01-03T00:00:00Z'}]})
-
+        .reply(200, { has_more: false, customers: [{ created_at: '2020-01-03T00:00:00Z' }] })
 
       let callCount = 0
+      const customers = []
       for await (const customer of client.customers.scroll({ filters: 'value' })) {
         ++callCount
+        customers.push(customer)
       }
 
       expect(callCount).to.equal(3)
+      expect(customers[0]).to.eql({ created_at: '2020-01-01T00:00:00Z' })
       await server.done()
     })
 
@@ -108,17 +109,20 @@ describe('Customers API', function () {
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
         .query({ filters: 'value', starting_after: '2019-12-31T23:59:00Z' })
-        .reply(200, {has_more: true, customers: [{created_at: '2020-01-01T00:00:00Z'}, {created_at: '2020-01-02T00:00:00Z'}]})
+        .reply(200, { has_more: true, customers: [{ created_at: '2020-01-01T00:00:00Z' }, { created_at: '2020-01-02T00:00:00Z' }] })
 
         .get('/v1/customers')
         .query({ filters: 'value', starting_after: '2020-01-02T00:00:00Z' })
-        .reply(200, {has_more: false, customers: [{created_at: '2020-01-03T00:00:00Z'}]})
+        .reply(200, { has_more: false, customers: [{ created_at: '2020-01-03T00:00:00Z' }] })
 
       let callCount = 0
+      const customers = []
       for await (const customer of client.customers.scroll({ starting_after: '2019-12-31T23:59:00Z', filters: 'value' })) {
         ++callCount
+        customers.push(customer)
       }
       expect(callCount).to.equal(3)
+      expect(customers[0]).to.eql({ created_at: '2020-01-01T00:00:00Z' })
       await server.done()
     })
 
@@ -126,45 +130,53 @@ describe('Customers API', function () {
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
         .query({ filters: 'value', starting_after: '2019-12-31T23:59:00Z', ending_before: '2020-12-31T23:59:00Z' })
-        .reply(200, {has_more: true, customers: [{created_at: '2020-01-01T00:00:00Z'}, {created_at: '2020-01-02T00:00:00Z'}]})
+        .reply(200, { has_more: true, customers: [{ created_at: '2020-01-01T00:00:00Z' }, { created_at: '2020-01-02T00:00:00Z' }] })
 
         .get('/v1/customers')
-        .query({ filters: 'value', starting_after: '2020-01-02T00:00:00Z', ending_before : '2020-12-31T23:59:00Z' })
-        .reply(200, {has_more: false, customers: [{created_at: '2020-01-03T00:00:00Z'}]})
+        .query({ filters: 'value', starting_after: '2020-01-02T00:00:00Z', ending_before: '2020-12-31T23:59:00Z' })
+        .reply(200, { has_more: false, customers: [{ created_at: '2020-01-03T00:00:00Z' }] })
 
       let callCount = 0
+      const customers = []
       for await (const customer of client.customers.scroll({
         starting_after: '2019-12-31T23:59:00Z',
-        ending_before : '2020-12-31T23:59:00Z',
+        ending_before: '2020-12-31T23:59:00Z',
         filters: 'value'
       })) {
         ++callCount
+        customers.push(customer)
       }
       expect(callCount).to.equal(3)
+      expect(customers[0]).to.eql({ created_at: '2020-01-01T00:00:00Z' })
       await server.done()
     })
 
     it('should scroll customers ascending', async function () {
-      let now = new Date().toISOString()
+      const now = new Date().toISOString()
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
         .query({ ending_before: now, filters: 'value' })
-        .reply(200, {has_more: true, customers: [
-          {created_at: '2020-01-04T00:00:00Z'},
-          {created_at: '2020-01-03T00:00:00Z'},
-          {created_at: '2020-01-02T00:00:00Z'}
-        ]})
+        .reply(200, {
+          has_more: true,
+          customers: [
+            { created_at: '2020-01-04T00:00:00Z' },
+            { created_at: '2020-01-03T00:00:00Z' },
+            { created_at: '2020-01-02T00:00:00Z' }
+          ]
+        })
         .get('/v1/customers')
         .query({ filters: 'value', ending_before: '2020-01-02T00:00:00Z' })
-        .reply(200, {has_more: false, customers: [{created_at: '2020-01-01T00:00:00Z'}]})
-
+        .reply(200, { has_more: false, customers: [{ created_at: '2020-01-01T00:00:00Z' }] })
 
       let callCount = 0
+      const customers = []
       for await (const customer of client.customers.scroll({ filters: 'value', ending_before: now })) {
         ++callCount
+        customers.push(customer)
       }
 
       expect(callCount).to.equal(4)
+      expect(customers[0]).to.eql({ created_at: '2020-01-04T00:00:00Z' })
       await server.done()
     })
   })

--- a/test/customers-api.spec.js
+++ b/test/customers-api.spec.js
@@ -87,11 +87,11 @@ describe('Customers API', function () {
     it('should scroll customers descending', async function () {
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
-        .query({ scroll: true, filters: 'value' })
+        .query({ filters: 'value', starting_after: '1970-01-01T00:00:00Z' })
         .reply(200, {has_more: true, customers: [{created_at: '2020-01-01T00:00:00Z'}, {created_at: '2020-01-02T00:00:00Z'}]})
 
         .get('/v1/customers')
-        .query({ scroll: true, filters: 'value', starting_after: '2020-01-02T00:00:00Z' })
+        .query({ filters: 'value', starting_after: '2020-01-02T00:00:00Z' })
         .reply(200, {has_more: false, customers: [{created_at: '2020-01-03T00:00:00Z'}]})
 
 
@@ -109,14 +109,14 @@ describe('Customers API', function () {
       let now = new Date().toISOString()
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
-        .query({ scroll: true, ending_before: now, filters: 'value' })
+        .query({ ending_before: now, filters: 'value' })
         .reply(200, {has_more: true, customers: [
           {created_at: '2020-01-04T00:00:00Z'},
           {created_at: '2020-01-03T00:00:00Z'},
           {created_at: '2020-01-02T00:00:00Z'}
         ]})
         .get('/v1/customers')
-        .query({ scroll: true, filters: 'value', ending_before: '2020-01-02T00:00:00Z' })
+        .query({ filters: 'value', ending_before: '2020-01-02T00:00:00Z' })
         .reply(200, {has_more: false, customers: [{created_at: '2020-01-01T00:00:00Z'}]})
 
 

--- a/test/customers-api.spec.js
+++ b/test/customers-api.spec.js
@@ -83,7 +83,7 @@ describe('Customers API', function () {
   })
 
   describe('scroll', async function () {
-    it('should scroll customers descending', async function () {
+    it('should scroll customers', async function () {
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
         .query({ filters: 'value', starting_after: '1970-01-01T00:00:00Z' })
@@ -105,7 +105,7 @@ describe('Customers API', function () {
       await server.done()
     })
 
-    it('should scroll customers descending and defined initial starting_after', async function () {
+    it('should scroll customers created after specific date', async function () {
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
         .query({ filters: 'value', starting_after: '2019-12-31T23:59:00Z' })
@@ -126,7 +126,7 @@ describe('Customers API', function () {
       await server.done()
     })
 
-    it('should scroll customers descending and defined initial starting_after and ending_before', async function () {
+    it('should scroll customers created between time range', async function () {
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')
         .query({ filters: 'value', starting_after: '2019-12-31T23:59:00Z', ending_before: '2020-12-31T23:59:00Z' })
@@ -151,7 +151,7 @@ describe('Customers API', function () {
       await server.done()
     })
 
-    it('should scroll customers ascending', async function () {
+    it('should scroll customers created before specific date', async function () {
       const now = new Date().toISOString()
       var server = nock('https://api.voucherify.io', reqWithoutBody)
         .get('/v1/customers')


### PR DESCRIPTION
Standard list customers API has limitation of available pages to be shown equal to 100.
To cover cases when you would like to fetch more, we must use scroll capabilities of the API.
The SDK simplifies it, making listing high volume of customers seamless. 

```
  for await (const customer of client.customers.scroll(params)) {
    console.log('Customer', customer)
  }
```