### PR TITLE
Removed deprecated redemption method

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ client.validations.validate(params)
 Methods are provided within `client.redemptions.*` namespace.
 
 - [Redeem Voucher](#redeem-voucher)
+- [Redeem Promotion's Tier](#redeem-promotions-tier)
 - [Redeem Loyalty Card](#redeem-loyalty-card)
 - [List Redemptions](#list-redemptions)
 - [Get Voucher's Redemptions](#get-vouchers-redemptions)

--- a/README.md
+++ b/README.md
@@ -320,7 +320,6 @@ client.validations.validate(params)
 Methods are provided within `client.redemptions.*` namespace.
 
 - [Redeem Voucher](#redeem-voucher)
-- [Redeem Promotion's Tier](#redeem-promotions-tier)
 - [Redeem Loyalty Card](#redeem-loyalty-card)
 - [List Redemptions](#list-redemptions)
 - [Get Voucher's Redemptions](#get-vouchers-redemptions)
@@ -335,10 +334,6 @@ client.redemptions.redeem(code, params)
 client.redemptions.redeem({code, ...params})
 client.redemptions.redeem({code, ...params}, tracking_id)
 client.redemptions.redeem(code, tracking_id) // use: client.redemptions.redeem(code, {customer: {source_id}})
-```
-#### [Redeem Promotion's Tier]
-```javascript
-client.redemptions.redeem(promotionsTier, params)
 ```
 #### [Redeem Loyalty Card]
 ```javascript


### PR DESCRIPTION
Removed redemption method for promotion tier from `Redemptions API` section. Correct redemption method for Promotion Tiers is in the `Promotions API` section.