### PR TITLE
enhancement(error): throw error objects instead of object literals

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -3,16 +3,10 @@
 const request = require('request')
 const when = require('when')
 const packageJson = require('../package')
+const VoucherifyError = require('./VoucherifyError')
 
-const errorMessage = (statusCode, body) => {
-  body = body || {}
-  if (typeof body === 'string') {
-    return 'Unexpected status code: ' + statusCode + ' - Details: ' + body
-  }
-  body.toString = function () {
-    return `Unexpected status code: ${statusCode} - Details: ${JSON.stringify(body)}`
-  }
-  return body
+const generateError = (statusCode, body) => {
+  return new VoucherifyError(statusCode, body)
 }
 
 const prepare = (callback) => {
@@ -22,7 +16,7 @@ const prepare = (callback) => {
     return {
       callback: function (error, res, body) {
         if (error || res.statusCode >= 400) {
-          callback(error || errorMessage(res.statusCode, body))
+          callback(error || generateError(res.statusCode, body))
           return
         }
 
@@ -34,7 +28,7 @@ const prepare = (callback) => {
       promise: deferred.promise,
       callback: function (error, res, body) {
         if (error || res.statusCode >= 400) {
-          deferred.reject(error || errorMessage(res.statusCode, body))
+          deferred.reject(error || generateError(res.statusCode, body))
           return
         }
 

--- a/src/VoucherifyError.js
+++ b/src/VoucherifyError.js
@@ -1,0 +1,19 @@
+class VoucherifyError extends Error {
+  constructor (statusCode, body) {
+    body = body || {}
+    const generatedMessage = generateMessage(body, statusCode)
+
+    super(body.message || generatedMessage)
+
+    Object.assign(this, body)
+  }
+}
+
+function generateMessage (body, statusCode) {
+  if (typeof body === 'string') {
+    return 'Unexpected status code: ' + statusCode + ' - Details: ' + body
+  }
+  return `Unexpected status code: ${statusCode} - Details: ${JSON.stringify(body)}`
+}
+
+module.exports = VoucherifyError

--- a/test/voucherify-client.spec.js
+++ b/test/voucherify-client.spec.js
@@ -44,10 +44,12 @@ describe('VocherifyClient', function () {
         name: 'customer name'
       })
         .catch(function (error) {
+          expect(error).to.be.instanceOf(Error)
           expect(error.code).to.equal(400)
           expect(error.message).to.equal('Duplicate resource key')
           expect(error.details).to.equal('Campaign with name: test campaign already exists.')
           expect(error.key).to.equal('duplicate_resource_key')
+          expect(error.stack).to.be.ok
           server.done()
           done()
         })
@@ -62,8 +64,10 @@ describe('VocherifyClient', function () {
         })
 
       client.customers.create({ name: 'customer name' }, function (error) {
+        expect(error).to.be.instanceOf(Error)
         expect(error.code).to.equal(401)
         expect(error.message).to.equal('No such app.')
+        expect(error.stack).to.be.ok
         server.done()
         done()
       })


### PR DESCRIPTION
[Throwing object/string literals is considered a bad practice](https://eslint.org/docs/rules/no-throw-literal), and we've had an incident today that would've been avoided if voucherify-sdk was throwing error objects instead of object literals because error objects offer useful fields for debugging such as `stack` it makes things easier.

This PR makes the SDK throw errors that extend the JS error constructor and copy all the fields from the body to the instance error, making all tests pass.

One thing to consider is the fact that in line 8 in VoucherifyError.js we're assigning all values from `body` to `this` which can overwrite one of the instance properties:
```
message
description
number

name
fileName
lineNumber
columnNumber
stack
```

I suppose overwriting the first 3 is okay and is intended, however overwriting the `stack` could be undesired since it's basically the main purpose of this PR.